### PR TITLE
aeButton type:plain has no box-shadow

### DIFF
--- a/src/components/aeButton/aeButton.scss
+++ b/src/components/aeButton/aeButton.scss
@@ -20,8 +20,10 @@
     }
   }
 
-  &:not(._size_smaller){/*_size_smaller is a special case*/
+  &:not(._size_smaller):not(._type_plain) {
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.11);
+  }
+  &:not(._size_smaller){/*_size_smaller is a special case*/
     &._type{
       &_plain {
         background-color: transparent;

--- a/src/components/aeButton/aeButton.scss
+++ b/src/components/aeButton/aeButton.scss
@@ -20,10 +20,10 @@
     }
   }
 
-  &:not(._size_smaller):not(._type_plain) {
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.11);
-  }
   &:not(._size_smaller){/*_size_smaller is a special case*/
+    &:not(._type_plain) {
+      box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.11);
+    }
     &._type{
       &_plain {
         background-color: transparent;


### PR DESCRIPTION
```
    <ae-button @click='close' size='small' type='plain'>
      <ae-icon slot='icon' name='close'/>
    </ae-button>
```
## before
<img width="52" alt="screen shot 2017-12-06 at 18 48 27" src="https://user-images.githubusercontent.com/415536/33676447-096af2d8-dab6-11e7-965b-853b413b0a62.png">


## after
<img width="51" alt="screen shot 2017-12-06 at 18 48 52" src="https://user-images.githubusercontent.com/415536/33676448-098bd9b2-dab6-11e7-8aa7-888b2e29ee0b.png">