### PR TITLE
Add AeModalLight component

### DIFF
--- a/src/components/aeButton/aeButton.js
+++ b/src/components/aeButton/aeButton.js
@@ -41,6 +41,10 @@ export default {
     invert: {
       type: Boolean,
       default: false
+    },
+    uppercase: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
@@ -65,13 +69,17 @@ export default {
     invertModifier () {
       return `_invert_${this.invert}`
     },
+    uppercaseModifier () {
+      return this.uppercase ? '_uppercase' : ''
+    },
     cssClass () {
       return [
         this.sizeModifier,
         this.typeModifier,
         this.activeModifier,
         this.hasLabelModifier,
-        this.invertModifier
+        this.invertModifier,
+        this.uppercaseModifier
       ]
     }
   }

--- a/src/components/aeButton/aeButton.md
+++ b/src/components/aeButton/aeButton.md
@@ -41,3 +41,10 @@ with aeIcon and label
   </ae-button>
 </div>
 ```
+
+```js
+<div>
+  <ae-button>Normal</ae-button>
+  <ae-button uppercase>Uppercase</ae-button>
+</div>
+```

--- a/src/components/aeButton/aeButton.scss
+++ b/src/components/aeButton/aeButton.scss
@@ -5,6 +5,7 @@
   border: none;
   border-radius: 100px;
   color: #fff;
+  font-weight: 500;
 
   &._has-label_false {
     padding:0;

--- a/src/components/aeButton/aeButton.scss
+++ b/src/components/aeButton/aeButton.scss
@@ -150,4 +150,7 @@
     }
   }
 
+  &._uppercase {
+    text-transform: uppercase;
+  }
 }

--- a/src/components/aeModalLight/aeModalLight.md
+++ b/src/components/aeModalLight/aeModalLight.md
@@ -1,0 +1,31 @@
+```js
+new Vue({
+  data(){ return { modalVisible: false } },
+  template: `
+    <div>
+      <ae-button @click="modalVisible = true">Show modal light</ae-button>
+      <ae-modal-light
+        v-if="modalVisible"
+        @close="modalVisible = false"
+        title="Delete Voting?"
+      >
+        You can easily add this aepp again, if you are regretting this action
+        <ae-button
+          size="smaller"
+          type="exciting"
+          uppercase
+          @click="modalVisible = false"
+          slot="buttons"
+        >cancel</ae-button>
+        <ae-button
+          size="smaller"
+          type="dramatic"
+          uppercase
+          @click="modalVisible = false"
+          slot="buttons"
+        >delete</ae-button>
+      </ae-modal-light>
+    </div>
+  `
+})
+```

--- a/src/components/aeModalLight/aeModalLight.vue
+++ b/src/components/aeModalLight/aeModalLight.vue
@@ -1,0 +1,81 @@
+<template>
+  <ae-overlay @click="close">
+    <div class="ae-modal-light">
+      <h1>{{title}}</h1>
+      <main>
+        <!-- Modal content -->
+        <slot />
+      </main>
+      <div class="buttons">
+        <slot name="buttons">
+          <ae-button size="smaller" uppercase @click="close">close</ae-button>
+        </slot>
+      </div>
+    </div>
+  </ae-overlay>
+</template>
+
+<script>
+import AeOverlay from '../aeOverlay/aeOverlay.vue'
+import AeButton from '../aeButton/aeButton.vue'
+import AeIcon from '../aeIcon/aeIcon.vue'
+
+export default {
+  name: 'ae-modal-light',
+  props: {
+    /**
+     * Modal title
+     */
+    title: String
+  },
+  components: { AeOverlay, AeButton, AeIcon },
+  methods: {
+    close () {
+      /**
+       * Close event
+       *
+       * @event close
+       * @type {undefined}
+       */
+      this.$emit('close')
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+  @import "../variables";
+
+  .ae-overlay {
+    display: flex;
+    padding: 10px;
+    box-sizing: border-box;
+
+    .ae-modal-light {
+      margin: auto;
+      padding: 20px;
+      border-radius: 10px;
+      box-shadow: 0 4px 8px 0 rgba(60, 60, 60, 0.1);
+      background: linear-gradient(to bottom, white, #f1f4f7);
+
+      h1 {
+        font-size: 24px;
+        font-weight: bold;
+        margin: 10px 0 7px 0;
+        text-align: center;
+      }
+
+      main {
+        text-align: center;
+        color: $grey;
+        line-height: 1.44;
+      }
+
+      .buttons {
+        display: flex;
+        justify-content: space-around;
+        margin-top: 25px;
+      }
+    }
+  }
+</style>

--- a/src/components/aeModalLight/index.js
+++ b/src/components/aeModalLight/index.js
@@ -1,0 +1,5 @@
+import aeModalLight from './aeModalLight.vue'
+
+export default function install (Vue) {
+  Vue.component('ae-modal-light', aeModalLight)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import AeLabel from './components/aeLabel'
 import AeLoader from './components/aeLoader'
 import AeMain from './components/aeMain'
 import AeModal from './components/aeModal'
+import AeModalLight from './components/aeModalLight'
 import AeOverlay from './components/aeOverlay'
 import AePanel from './components/aePanel'
 import AeSwitch from './components/aeSwitch'
@@ -39,6 +40,7 @@ const AeppComponents = {
   AeLoader,
   AeMain,
   AeModal,
+  AeModalLight,
   AeOverlay,
   AePanel,
   AeSwitch,
@@ -72,6 +74,7 @@ export { default as AeLabel } from './components/aeLabel/aeLabel.vue'
 export { default as AeLoader } from './components/aeLoader/aeLoader.vue'
 export { default as AeMain } from './components/aeMain/aeMain.vue'
 export { default as AeModal } from './components/aeModal/aeModal.vue'
+export { default as AeModalLight } from './components/aeModalLight/aeModalLight.vue'
 export { default as AeOverlay } from './components/aeOverlay/aeOverlay.vue'
 export { default as AePanel } from './components/aePanel/aePanel.vue'
 export { default as AeSwitch } from './components/aeSwitch/aeSwitch.vue'


### PR DESCRIPTION
![screenshot from 2018-01-17 17-55-05](https://user-images.githubusercontent.com/9007851/35031772-1cf8373c-fbb0-11e7-842e-b40ed76e6ea7.png)
https://app.zeplin.io/project/59e4cf99fc0bb2f99a89551b/screen/5a27ffe4f9a38cac5e8ed165

I decided to implement it as a separate component because otherwise, code of AeModal becomes too complicated. Maybe will be better to remove fullscreen-on-mobile functionality of AeModal, but this functionality has a quite successfully usage in the Response app.

#16