### PR TITLE
AeLabel help-type supporst all types (change suggestion to #56)

### DIFF
--- a/src/components/aeButton/aeButton.js
+++ b/src/components/aeButton/aeButton.js
@@ -1,11 +1,6 @@
 import AeLink from '../aeLink/aeLink.vue'
+import {TYPE_PROPERTY_VALUES as aeButtonTypes} from '../../constants'
 
-const aeButtonTypes = [
-  'boring',
-  'normal',
-  'exciting',
-  'dramatic'
-]
 const aeButtonSizes = [
   'smaller',
   'small',

--- a/src/components/aeLabel/aeLabel.vue
+++ b/src/components/aeLabel/aeLabel.vue
@@ -4,13 +4,15 @@
       <!-- Label content -->
       <slot />
     </div>
-    <div class="help" :class="helpType">
+    <div :class="['help', typeModifier]">
       {{helpText}}
     </div>
   </label>
 </template>
 
 <script>
+  import {TYPE_PROPERTY_VALUES as types} from '../../constants'
+
   export default {
     name: 'ae-label',
     props: {
@@ -19,11 +21,17 @@
        */
       'help-text': String,
       /**
-       * Type of help field, possible values: 'exciting', 'dramatic'
+       * Type of help field, possible values: 'boring', 'normal', 'exciting', 'dramatic'
        */
       'help-type': {
         type: String,
-        validator: value => ['exciting', 'dramatic'].includes(value)
+        default: 'normal',
+        validator: value => types.includes(value)
+      }
+    },
+    computed: {
+      typeModifier () {
+        return `_type_${this.helpType}`
       }
     }
   }
@@ -49,16 +57,15 @@
       font-size: 13px;
       text-align: right;
       text-transform: none;
-      color: $grey;
       margin-left: 5px;
       line-height: 14px;
 
-      &.exciting {
-        color: $aubergine;
-      }
-
-      &.dramatic {
-        color: $maegenta;
+      &._type {
+        @each $type in map_keys($type-color-map){
+          &_#{$type}{
+            color: map_get($type-color-map, $type);
+          }
+        }
       }
     }
   }

--- a/src/components/variables.scss
+++ b/src/components/variables.scss
@@ -10,5 +10,12 @@ $black: #000000;
 $maegenta: #f03c6e;
 $plum: #c69cd0;
 
+$type-color-map: (
+  'boring': $silver,
+  'normal': $grey,
+  'exciting': $aubergine,
+  'dramatic': $maegenta
+);
+
 $container-width: 880px;
 $screen-phone: 480px;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,6 @@
+export const TYPE_PROPERTY_VALUES = [
+  'boring',
+  'normal',
+  'exciting',
+  'dramatic'
+]


### PR DESCRIPTION
This version of #56 
- supports all types ('boring', 'normal', 'exciting', 'dramatic')
- makes 'normal' the default type (which it implicitly already was)
- follows our CSS modifier class name convention