### PR TITLE
fix squash image when right header is added

### DIFF
--- a/src/components/aeIdentity/aeIdentity.scss
+++ b/src/components/aeIdentity/aeIdentity.scss
@@ -90,7 +90,8 @@
 }
 
 .balances {
-  width: calc(100% - 23px);
+  width: auto;
+  flex-grow: 1;
 }
 
 .balance {


### PR DESCRIPTION
fixes image being squashed when right header is added.
![image](https://user-images.githubusercontent.com/1866811/36500545-89e4be5e-173c-11e8-8c8e-7394278209c2.png)

![image](https://user-images.githubusercontent.com/1866811/36500597-a35b8412-173c-11e8-8f5f-43f58adc0d57.png)

