### PR TITLE
AeIdentity: Fix default value of 'identity' prop

### DIFF
--- a/src/components/aeIdentity/aeIdentity.js
+++ b/src/components/aeIdentity/aeIdentity.js
@@ -15,11 +15,11 @@ export default {
     */
     identity: {
       type: Object,
-      default: {
+      default: () => ({
         address: '0x0',
         tokenBalance: new BN('0', 10),
         balance: new BN('0', 10)
-      }
+      })
     },
     /**
     * Is this an identity activated/selected (magenta) or not (grey)?


### PR DESCRIPTION
[Vue warn]: Invalid default value for prop "identity": Props with type Object/Array must use a factory function to return the default value.

found in

---> &lt;AeIdentity&gt;