### PR TITLE
Improvements in vue event modifiers

### DIFF
--- a/src/components/aeAppIcon/aeAppIcon.js
+++ b/src/components/aeAppIcon/aeAppIcon.js
@@ -1,15 +1,18 @@
+import mixin from '../../mixins/helper'
+
 /**
  * Displays an App Icon
  */
 export default {
   name: 'ae-app-icon',
+  mixins: [mixin],
   props: {
     /**
-     * src propery, location of the icon
+     * src property, location of the icon
      */
     src: {
-      type: String,
-      required: true
+      required: true,
+      type: String
     }
   },
   computed: {
@@ -18,5 +21,8 @@ export default {
         'background-image': `url(${this.src})`
       }
     }
+  },
+  methods: {
+
   }
 }

--- a/src/components/aeAppIcon/aeAppIcon.test.js
+++ b/src/components/aeAppIcon/aeAppIcon.test.js
@@ -1,0 +1,46 @@
+import { shallow } from 'vue-test-utils'
+import AeAppIcon from './aeAppIcon.vue'
+
+describe('aeAppIcon', () => {
+  describe('render', () => {
+    it('renders an element with the src property as back ground image', () => {
+      const src = 'http:/example.com/someimage.png'
+      const wrapper = shallow(AeAppIcon, {
+        propsData: { src }
+      })
+
+      const image = wrapper.vm.$refs.iconImage
+      const bgImage = image.style.backgroundImage
+      expect(bgImage.indexOf(src)).toBeGreaterThan(-1)
+    })
+  })
+
+  describe('events', () => {
+    describe('click', () => {
+      it('emits click when root element is clicked', () => {
+        const wrapper = shallow(AeAppIcon, {
+          propsData: { src: '' }
+        })
+        const clickEvent = new Event('click')
+        wrapper.element.dispatchEvent(clickEvent)
+        const emittedClick = wrapper.emitted().click
+        expect(emittedClick.length).toBe(1)
+        const eventArg = emittedClick[0][0]
+        expect(eventArg.type).toBe('click')
+      })
+
+      it('emits click when icon is clicked', () => {
+        const wrapper = shallow(AeAppIcon, {
+          propsData: { src: '' }
+        })
+        const iconElement = wrapper.vm.$refs.iconImage
+        const clickEvent = new Event('click')
+        iconElement.dispatchEvent(clickEvent)
+        const emittedClick = wrapper.emitted().click
+        expect(emittedClick.length).toBe(1)
+        const eventArg = emittedClick[0][0]
+        expect(eventArg.type).toBe('click')
+      })
+    })
+  })
+})

--- a/src/components/aeAppIcon/aeAppIcon.vue
+++ b/src/components/aeAppIcon/aeAppIcon.vue
@@ -1,9 +1,16 @@
 <template>
-  <div class="ae-app-icon app-icon">
-    <div :style='cssStyle' class="icon-image">
+  <div class="ae-app-icon app-icon" @click="forwardEvent">
+    <div
+      :style="cssStyle"
+      class="icon-image"
+      ref="iconImage"
+      @click="forwardEvent"
+    >
     </div>
   </div>
 </template>
-<script src='./aeAppIcon.js'/>
+<script src='./aeAppIcon.js'>
+  export {default} from './aeAppIcon'
+</script>
 /* eslint no-unused-expressions: "off" */
 <style src='./aeAppIcon.css'/>

--- a/src/components/aeButton/aeButton.test.js
+++ b/src/components/aeButton/aeButton.test.js
@@ -61,21 +61,28 @@ describe('AeButton', () => {
 
   describe('events', () => {
     describe('click', () => {
+      const testEmittedClick = emittedClick => {
+        expect(emittedClick.length).toBe(1)
+        expect(emittedClick[0][0]).toBeTruthy()
+        const event = emittedClick[0][0]
+        expect(event.type).toBe('click')
+      }
+
       it('clicking on icon emits click', () => {
         const wrapper = renderIcon()
-
-        const icon = wrapper.find('[data-slot="icon"]')
+        const icon = wrapper.find(ICON_SELECTOR)
         icon.trigger('click')
-        expect(wrapper.emitted().click).toBeTruthy()
+        return wrapper.vm.$nextTick().then(() => {
+          testEmittedClick(wrapper.emitted().click)
+        })
       })
 
       it('clicking on label emits click', () => {
         const wrapper = renderLabel()
-
-        wrapper.vm.$nextTick().then(() => {
+        return wrapper.vm.$nextTick().then(() => {
           const icon = wrapper.find(LABEL_SELECTOR)
           icon.trigger('click')
-          expect(wrapper.emitted().click).toBeTruthy()
+          testEmittedClick(wrapper.emitted().click)
         })
       })
     })

--- a/src/components/aeButton/aeButton.vue
+++ b/src/components/aeButton/aeButton.vue
@@ -3,7 +3,7 @@
     :is="to ? 'ae-link' : 'button'"
     class="ae-button"
     :class="cssClass"
-    @click="$emit('click')"
+    @click="$emit('click', $event)"
     :to="to"
   >
     <div class="inner">

--- a/src/mixins/helper.js
+++ b/src/mixins/helper.js
@@ -9,6 +9,9 @@ export default {
         seed: address
       })
     },
+    forwardEvent (event) {
+      this.$emit(event.type, event)
+    },
     readableToken (balance) {
       return numeral(unit.fromWei(balance.toString(10), 'ether')).format('0,0.[000]')
     },


### PR DESCRIPTION
Recently I wanted to use the `@click.prevent` modified event on a AeButton. Which did not work, because currently AeButton does not  forward the dispatched native event.

In this PR I made the click event for AeButton and AeAppIcon modifiable.