### PR TITLE
Fix issue #69/AeAddress: Accept ak$ and ok$ addresses

### DIFF
--- a/src/components/aeAddress/aeAddress.js
+++ b/src/components/aeAddress/aeAddress.js
@@ -5,7 +5,7 @@ function startAndEnd (str, start = 6, end = 6) {
     str.substr(str.length - end, str.length)
 }
 function addressValid (address) {
-  return /^0x[0-9a-fA-F]{40}$/i.test(address)
+  return /^((0x[0-9a-fA-F]{40})|([ao]k\$[0-9a-zA-Z]{94}))$/.test(address)
 }
 
 /**

--- a/src/components/aeAddress/aeAddress.md
+++ b/src/components/aeAddress/aeAddress.md
@@ -6,8 +6,17 @@
 <ae-address size='short' address='0xfa617481af59ebec80e8d529f1e2d1b3751468f3'/>
 ```
 ```js
-<ae-address show-avatar address='0xfa617481af59ebec80e8d529f1e2d1b3751468f3'/>\
+<ae-address show-avatar address='0xfa617481af59ebec80e8d529f1e2d1b3751468f3'/>
 ```
 ```js
 <ae-address show-avatar size='short' address='0xfa617481af59ebec80e8d529f1e2d1b3751468f3'/>
 ```
+
+```js
+<ae-address show-avatar size='short' address='0xfa617481af59ebec80e8d529f1e2d1b3751468f3'/>
+```
+
+```js
+<ae-address show-avatar size='short' address='ak$3K1hfV4j3HdKHyUgyDSTsK9pm1nvBK5V72UYQ41UuRJ7ei1QWskoEPZzpzgk5WJCi4efcRrCvoLHMrE9PBG1WZ1zL8q5Bz'/>
+```
+


### PR DESCRIPTION
Extended the validation regex to accept addresses with a length of 97 characters and starting with ak$ or ok$.