### PR TITLE
AeIdentity fixes

### DIFF
--- a/src/components/aeIdentity/aeIdentity.js
+++ b/src/components/aeIdentity/aeIdentity.js
@@ -55,9 +55,6 @@ export default {
     chunkAddress () {
       return this.identity.address.match(/.{1,7}/g)
     },
-    hasSlot () {
-      return this.$slots.default
-    },
     classObject () {
       return {
         'ae-identity': true,

--- a/src/components/aeIdentity/aeIdentity.scss
+++ b/src/components/aeIdentity/aeIdentity.scss
@@ -65,11 +65,6 @@
 }
 
 
-.ae-identity ,
-.ae-identity * {
-  transition:0.4s;
-}
-
 .identity-info{
   text-overflow: ellipsis;
   text-transform: uppercase;

--- a/src/components/aeIdentity/aeIdentity.vue
+++ b/src/components/aeIdentity/aeIdentity.vue
@@ -23,7 +23,7 @@
           {{chunk}}
         </div>
       </div>
-      <div class="footer" v-if="hasSlot">
+      <div class="footer" v-if="$slots.default">
         <slot></slot>
       </div>
     </div>


### PR DESCRIPTION
Perhaps `this.$slots.default` is not a reactive variable since `hasSlot` contains an old value of `$slots.default` after its update.
@Philip-Nunoo is there any reason to enable `transition` for the root node and all children?