### PR TITLE
AeAmountInput: Pass "id" property to child input

### DIFF
--- a/src/components/aeAmountInput/aeAmountInput.md
+++ b/src/components/aeAmountInput/aeAmountInput.md
@@ -17,3 +17,15 @@
     `
   })
 ```
+
+```vue
+<template>
+<div>
+  <ae-label for="example-amount-input">Label for amount input</ae-label>
+  <ae-amount-input id="example-amount-input" />
+</div>
+</template>
+<script>
+export default {}
+</script>
+```

--- a/src/components/aeAmountInput/aeAmountInput.vue
+++ b/src/components/aeAmountInput/aeAmountInput.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="ae-amount-input">
     <ae-input
+      :id="id"
       type="number"
       monospace
       :value="value.amount"
@@ -50,6 +51,7 @@ export default {
       type: Object,
       default: () => ({ symbol: this.getUnits })
     },
+    id: undefined,
     placeholder: undefined,
     /**
      * Array of available units, every unit is object containing `symbol` and `name` keys


### PR DESCRIPTION
Make possible to connect AeAmountInput with AeLabel by "id"/"for" properties.