### PR TITLE
Binding Vue context in Vue.use, on all component export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ AeppComponents.install = Vue =>
   Object.keys(AeppComponents)
     .filter(component => component !== 'install')
     .map(component => AeppComponents[component])
-    .forEach(Vue.use)
+    .forEach(Vue.use.bind(Vue))
 
 export default AeppComponents
 


### PR DESCRIPTION
There's an issue when importing all of the components into a Vue app, the Vue.use doesn't have the Vue object context, and throws an error.

Fixed it by binding the Vue context to the Vue.use function.