### PR TITLE
Fix ethereum blockies

### DIFF
--- a/__mocks__/@download/blockies.js
+++ b/__mocks__/@download/blockies.js
@@ -1,0 +1,1 @@
+export function renderIcon () {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,11 @@
         }
       }
     },
+    "@download/blockies": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@download/blockies/-/blockies-1.0.3.tgz",
+      "integrity": "sha512-iGDh2M6pFuXg9kyW+U//963LKylSLFpLG5hZvUppCjhkiDwsYquQPyamxCQlLASYySS3gGKAki2eWG9qIHKCew=="
+    },
     "@types/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -4131,11 +4136,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
-    },
-    "ethereum-blockies": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ethereum-blockies/-/ethereum-blockies-0.1.1.tgz",
-      "integrity": "sha1-h5/pWd7vSSp6krQ9w0ro3C7lkfw="
     },
     "ethjs-unit": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "dependencies": {
-    "ethereum-blockies": "^0.1.1",
+    "@download/blockies": "^1.0.3",
     "ethjs-unit": "^0.1.6",
     "normalize.css": "^7.0.0",
     "numeral": "^2.0.6",

--- a/src/components/aeIdentityAvatar/aeIdentityAvatar.js
+++ b/src/components/aeIdentityAvatar/aeIdentityAvatar.js
@@ -1,4 +1,4 @@
-import { render } from 'ethereum-blockies'
+import { renderIcon } from '@download/blockies'
 
 /**
  * Displays the representation of an ethereum address as an avatar
@@ -25,7 +25,7 @@ export default {
   },
   methods: {
     renderBlockie () {
-      render({ seed: this.address }, this.$refs.blockie)
+      renderIcon({ seed: this.address }, this.$refs.blockie)
     }
   }
 }


### PR DESCRIPTION
Actually, `ethereum-blockies@0.1.1` is broken because of lack of [this change](https://github.com/ethereum/blockies/commit/6eefa4521212216fba9f85feb7570b3ba543e238).  Yesterday it was merged into the upstream repository, it's owner has published a new version. But I still have some problems using this package, I have [made a PR](https://github.com/download13/blockies/pull/11) and waiting for a new version.