### PR TITLE
Drop webpack aliases

### DIFF
--- a/config/global.requires.js
+++ b/config/global.requires.js
@@ -1,7 +1,7 @@
 /**
  * Importing SCSS
  */
-import '@source/base/_index.scss'
+import '../src/base/_index.scss'
 
 /**
  * Importing Libraries

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -156,14 +156,6 @@ module.exports = {
     // https://webpack.js.org/plugins/module-concatenation-plugin/
     new webpack.optimize.ModuleConcatenationPlugin()
   ],
-  resolve: {
-    alias: {
-      // Global paths
-      '@source': path.resolve(__dirname, '../src'),
-      '@public': path.resolve(__dirname, '../public'),
-    },
-    extensions: ['.js', '.vue', '.json']
-  },
   // Fetching all dependencies and
   // creates an object assigned to externals
   // which bypasses the dependencies

--- a/src/base/variables/_paths.scss
+++ b/src/base/variables/_paths.scss
@@ -4,6 +4,6 @@
 // *****************************
 //------------------------------
 
-$path-fonts: "~@public/fonts/" !default;
-$path-images: "~@public/images/" !default;
-$path-icons: "~@public/icons/" !default;
+$path-fonts: "../../public/fonts/" !default;
+$path-images: "../../public/images/" !default;
+$path-icons: "../../public/icons/" !default;

--- a/src/components/ae-button/ae-button.js
+++ b/src/components/ae-button/ae-button.js
@@ -1,4 +1,4 @@
-import { events } from '@source/mixins';
+import { events } from '../../mixins';
 
 export default {
   name: 'ae-button',

--- a/src/components/ae-input/ae-input.js
+++ b/src/components/ae-input/ae-input.js
@@ -1,4 +1,4 @@
-import { events } from '@source/mixins';
+import { events } from '../../mixins';
 
 export default {
   name: 'ae-input',

--- a/src/components/aeAppIcon/aeAppIcon.js
+++ b/src/components/aeAppIcon/aeAppIcon.js
@@ -1,4 +1,4 @@
-import mixin from '@source/core/mixins/helper';
+import mixin from '../../core/mixins/helper';
 
 /**
  * Displays an App Icon

--- a/src/components/aeButton/aeButton.js
+++ b/src/components/aeButton/aeButton.js
@@ -1,5 +1,5 @@
 import AeLink from '../aeLink/aeLink.vue';
-import {TYPE_PROPERTY_VALUES as aeButtonTypes} from '@source/core/constants';
+import {TYPE_PROPERTY_VALUES as aeButtonTypes} from '../../core/constants';
 
 const aeButtonSizes = [
   'smaller',

--- a/src/components/aeHeader/aeHeader.vue
+++ b/src/components/aeHeader/aeHeader.vue
@@ -6,7 +6,7 @@
         <slot name="mobile-left" />
       </div>
       <ae-link class="title" to="/">
-        <img :src="require('@public/images/logo-small.png')" alt="Go to main page" />
+        <img :src="require('../../../public/images/logo-small.png')" alt="Go to main page" />
         {{name}}
       </ae-link>
       <div class="desktop-right">

--- a/src/components/aeIcon/aeIcon.js
+++ b/src/components/aeIcon/aeIcon.js
@@ -1,4 +1,4 @@
-import * as iconSvgStrings from '@public/icons';
+import * as iconSvgStrings from '../../../public/icons';
 
 const aeIconTypes = [
   'plain',

--- a/src/components/aeIdentity/aeIdentity.js
+++ b/src/components/aeIdentity/aeIdentity.js
@@ -1,6 +1,6 @@
 import aeIdentityLight from '../aeIdentityLight/aeIdentityLight.vue';
 import aeIdentityBackground from '../aeIdentityBackground/aeIdentityBackground.vue';
-import helperMixin from '@source/core/mixins/helper';
+import helperMixin from '../../core/mixins/helper';
 
 /**
  * Displays an Identity with an avatar blockie, the address and an amount of ether

--- a/src/components/aeIdentityBackground/aeIdentityBackground.js
+++ b/src/components/aeIdentityBackground/aeIdentityBackground.js
@@ -1,4 +1,4 @@
-import {TYPE_PROPERTY_VALUES as types} from '@source/core/constants';
+import {TYPE_PROPERTY_VALUES as types} from '../../core/constants';
 
 export default {
   name: 'ae-identity-background',

--- a/src/components/aeIdentityLight/aeIdentityLight.js
+++ b/src/components/aeIdentityLight/aeIdentityLight.js
@@ -1,5 +1,5 @@
 import aeIdentityAvatar from './../aeIdentityAvatar/aeIdentityAvatar.vue';
-import helperMixin from '@source/core/mixins/helper';
+import helperMixin from '../../core/mixins/helper';
 import BN from 'bn.js';
 import unit from 'ethjs-unit';
 import numeral from 'numeral';

--- a/src/components/aeLabel/aeLabel.vue
+++ b/src/components/aeLabel/aeLabel.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import {TYPE_PROPERTY_VALUES as types} from '@source/core/constants';
+import {TYPE_PROPERTY_VALUES as types} from '../../core/constants';
 
 export default {
   name: 'ae-label',

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,21 @@
 /**
  * Importing SCSS
  */
-import '@source/base/_index.scss';
+import './base/_index.scss';
 
 /**
  * Vue Helpers
  */
-export * as mixins from '@source/mixins';
-export * as directives from '@source/directives';
-export * as filters from '@source/filters';
+export * as mixins from './mixins';
+export * as directives from './directives';
+export * as filters from './filters';
 
 /**
  * Helper functions
  */
-export { constants, helper } from '@source/core';
+export { constants, helper } from './core';
 
 /**
  * Exporting default component list
  */
-export { default } from '@source/components';
+export { default } from './components';


### PR DESCRIPTION
In addition to arguments in [the similar PR](https://github.com/aeternity/aepp-identity/pull/142) I would like to add that custom aliases makes mode difficult to build components package as a dependency of another project, when it is imported by `@aeternity/aepp-components/src`.
To build components package from the source code can be useful, for example, to enable tree shaking.