### PR TITLE
Import `vue-touch` explicitly

### DIFF
--- a/config/global.requires.js
+++ b/config/global.requires.js
@@ -6,10 +6,4 @@ import '../src/styles/index.scss'
 /**
  * Importing Libraries
  */
-import Vue from 'vue'
-import VueTouch from 'vue-touch'
-
-/**
- * Installing Libraries
- */
-Vue.use(VueTouch)
+import 'vue'

--- a/src/components/ae-flip/ae-flip.vue
+++ b/src/components/ae-flip/ae-flip.vue
@@ -19,8 +19,11 @@
   </v-touch>
 </template>
 <script>
+import { component } from 'vue-touch';
+
 export default {
   name: 'ae-flip',
+  components: { VTouch: component },
   data() {
     return { rotation: 0 };
   },

--- a/src/components/ae-flip/index.js
+++ b/src/components/ae-flip/index.js
@@ -1,8 +1,6 @@
-import VueTouch from 'vue-touch';
 import AeFlip from './ae-flip.vue';
 
 export const install = function (Vue) {
-  Vue.use(VueTouch);
   Vue.component('ae-flip', AeFlip);
 };
 


### PR DESCRIPTION
Explicit imports of `vue-touch` in components that actually use it make possible to tree-shake this dependency in case if these components are not used in a specific project.