### PR TITLE
Refactor AeCheck

### DIFF
--- a/src/components/ae-check/ae-check.md
+++ b/src/components/ae-check/ae-check.md
@@ -7,26 +7,30 @@
 <template>
   <div>
     <h2>Radio</h2>
-    <label>
-      <ae-check v-model="singleChoice" value="1" type="radio" />
-      Radio button 1
-    </label>
-    <label>
-      <ae-check v-model="singleChoice" value="2" type="radio" />
-      Radio button 2
-    </label>
-    <label>value: {{ singleChoice }}</label>
+    <div>
+      <ae-check v-model="singleChoice" value="1" type="radio">
+        Radio button 1
+      </ae-check>
+    </div>
+    <div>
+      <ae-check v-model="singleChoice" value="2" type="radio">
+        Radio button 2
+      </ae-check>
+    </div>
+    <div>value: {{ singleChoice }}</div>
 
     <h2>Checkbox</h2>
-    <label>
-      <ae-check v-model="multipleChoices" value="1" type="checkbox" />
-      Checkbox 1
-    </label>
-    <label>
-      <ae-check v-model="multipleChoices" value="2" type="checkbox" />
-      Checkbox 2
-    </label>
-    <label>value: {{ multipleChoices }}</label>
+    <div>
+      <ae-check v-model="multipleChoices" value="1" type="checkbox">
+        Checkbox 1
+      </ae-check>
+    </div>
+    <div>
+      <ae-check v-model="multipleChoices" value="2" type="checkbox">
+        Checkbox 2
+      </ae-check>
+    </div>
+    <div>value: {{ multipleChoices }}</div>
   </div>
 </template>
 

--- a/src/components/ae-check/ae-check.md
+++ b/src/components/ae-check/ae-check.md
@@ -1,52 +1,23 @@
-```jsx
-  <ae-check name="hello">
-    <ae-text>Checking</ae-text> 
-  </ae-check>
-``` 
-
-### slot: content
-```jsx
-  <ae-check name="content" extend>
-    <div slot="content">
-      <h1> heading </h1>
-      <span>sub heading </span>
-    </div>
-  </ae-check>
-``` 
-
-### prop: align
-```jsx
-  <ae-check name="align" align="left" extend>
-    <div slot="content">
-      <h1> heading </h1>
-      <span>sub heading </span>
-    </div>
-  </ae-check>
+```vue
+<ae-check />
 ``` 
 
 ### prop: type
-```jsx
-  <ae-list>
-    <ae-list-item>
-        <ae-check name="align" type="radio" align="left" extend>
-          <div slot="content">
-            <h1> radio 1 </h1>
-          </div>
-        </ae-check>
-    </ae-list-item>
-    <ae-list-item>
-        <ae-check name="align" type="radio" align="left" extend>
-          <div slot="content">
-            <h1> radio 2 </h1>
-          </div>
-        </ae-check>
-    </ae-list-item>
-  </ae-list>
+```vue
+<div>
+  <label>
+    <ae-check name="example" type="radio" />
+    radio 1
+  </label>
+  <br>
+  <label>
+    <ae-check name="example" type="radio" />
+    radio 2
+  </label>
+</div>
 ``` 
 
 ### prop: disabled
-```jsx
-  <ae-check name="hello" disabled>
-    <ae-text>Checking</ae-text> 
-  </ae-check>
+```vue
+<ae-check disabled />
 ``` 

--- a/src/components/ae-check/ae-check.md
+++ b/src/components/ae-check/ae-check.md
@@ -4,17 +4,46 @@
 
 ### prop: type
 ```vue
-<div>
-  <label>
-    <ae-check name="example" type="radio" />
-    radio 1
-  </label>
-  <br>
-  <label>
-    <ae-check name="example" type="radio" />
-    radio 2
-  </label>
-</div>
+<template>
+  <div>
+    <h2>Radio</h2>
+    <label>
+      <ae-check v-model="singleChoice" value="1" type="radio" />
+      Radio button 1
+    </label>
+    <label>
+      <ae-check v-model="singleChoice" value="2" type="radio" />
+      Radio button 2
+    </label>
+    <label>value: {{ singleChoice }}</label>
+
+    <h2>Checkbox</h2>
+    <label>
+      <ae-check v-model="multipleChoices" value="1" type="checkbox" />
+      Checkbox 1
+    </label>
+    <label>
+      <ae-check v-model="multipleChoices" value="2" type="checkbox" />
+      Checkbox 2
+    </label>
+    <label>value: {{ multipleChoices }}</label>
+  </div>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    singleChoice: undefined,
+    multipleChoices: ['2'],
+  })
+}
+</script>
+
+<style scoped>
+label:not(.ae-check) {
+  display: block;
+}
+</style>
 ``` 
 
 ### prop: disabled

--- a/src/components/ae-check/ae-check.vue
+++ b/src/components/ae-check/ae-check.vue
@@ -14,6 +14,7 @@
     </span>
   </label>
 </template>
+
 <script>
 export default {
   name: 'ae-check',
@@ -26,19 +27,15 @@ export default {
      * ID of the component/input
      */
     id: String,
-
     /**
      * Name of component
      */
     name: String,
-
     /**
      * value of component
      */
     value: { type: [String, Number, Boolean], default: undefined },
-
     checked: { type: [Array, String, Number, Boolean], default: false },
-
     /**
      * Define the type of the input
      */
@@ -46,7 +43,6 @@ export default {
       type: String,
       default: 'checkbox',
     },
-
     /**
      * Puts the component in disabled state
      */

--- a/src/components/ae-check/ae-check.vue
+++ b/src/components/ae-check/ae-check.vue
@@ -7,10 +7,9 @@
       :value="value"
       :checked="isChecked"
       :disabled="disabled"
-      @change="change"
-    >
-    <span class="indicator">
-      ✓
+      @change="change">
+    <span class="ae-check-button">
+      <slot />
     </span>
   </label>
 </template>
@@ -74,10 +73,11 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
+@import '../../styles/globals/functions';
 @import '../../styles/variables/colors';
 @import '../../styles/variables/animations';
 @import '../../styles/variables/typography';
-@import '../../styles/globals/functions';
+@import '../../styles/placeholders/typography';
 
 .ae-check {
   user-select: none;
@@ -116,11 +116,11 @@ export default {
 }
 
 .ae-check-button {
-  @include size(24px);
   @extend %face-sans-base;
 
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   padding-left: rem(32px);
   min-width: rem(32px);
   min-height: rem(24px);
@@ -132,25 +132,25 @@ export default {
     content: ' ';
     top: 0;
     bottom: 0;
-    left: 0;
+    left: 4px;
     transition: all $base-transition-time;
   }
 
   &:before {
-    @include size(24px);
-
     background: $color-white;
     border: 2px solid $color-neutral-positive-1;
     border-radius: 50%;
     box-shadow: 0 0 16px $color-shadow-alpha-15;
+    width: 24px;
+    height: 24px;
   }
 
   &:after {
-    @include size(24px);
-
     background: url("./images/check.svg") no-repeat center;
     background-size: rem(12px);
     opacity: 0;
+    width: 24px;
+    height: 24px;
   }
 }
 </style>

--- a/src/components/ae-check/ae-check.vue
+++ b/src/components/ae-check/ae-check.vue
@@ -1,12 +1,7 @@
 <template>
-  <label
-    class="ae-check"
-    :class="{ [align]: Boolean(align), extend }">
+  <label class="ae-check">
     <input :type="type" :name="name" :value="value" :disabled="disabled">
-    <span class="ae-check-button">
-      <slot />
-    </span>
-    <slot class="ae-check-content" name="content"/>
+    <span class="ae-check-button" />
   </label>
 </template>
 <script>
@@ -35,20 +30,6 @@ export default {
       type: String,
       default: 'checkbox',
     },
-
-    /**
-     * Align the content slot:
-     * `left`
-     */
-    align: {
-      type: String,
-      validator: value => ['left'].includes(value),
-    },
-
-    /**
-     * Extend the check component full width
-     */
-    extend: Boolean,
 
     /**
      * Puts the component in disabled state

--- a/src/components/ae-check/ae-check.vue
+++ b/src/components/ae-check/ae-check.vue
@@ -1,7 +1,7 @@
 <template>
   <label
     class="ae-check"
-    :class="{ [fill]: Boolean(fill), [align]: Boolean(align), extend }">
+    :class="{ [align]: Boolean(align), extend }">
     <input :type="type" :name="name" :value="value" :disabled="disabled">
     <span class="ae-check-button">
       <slot />

--- a/src/components/ae-check/ae-check.vue
+++ b/src/components/ae-check/ae-check.vue
@@ -1,9 +1,8 @@
 <template>
   <label
-    :for="id"
     class="ae-check"
-    :class="{ [align]: Boolean(align), extend }">
-    <input :id="id" :type="type" :name="name" :value="value" :disabled="disabled">
+    :class="{ [fill]: Boolean(fill), [align]: Boolean(align), extend }">
+    <input :type="type" :name="name" :value="value" :disabled="disabled">
     <span class="ae-check-button">
       <slot />
     </span>

--- a/src/components/ae-check/ae-check.vue
+++ b/src/components/ae-check/ae-check.vue
@@ -1,7 +1,10 @@
 <template>
   <label class="ae-check">
     <input :type="type" :name="name" :value="value" :disabled="disabled">
-    <span class="ae-check-button" />
+      :id="id"
+    <span class="indicator">
+      ✓
+    </span>
   </label>
 </template>
 <script>
@@ -42,7 +45,10 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import '../../styles/globals';
+@import '../../styles/variables/colors';
+@import '../../styles/variables/animations';
+@import '../../styles/variables/typography';
+@import '../../styles/globals/functions';
 
 .ae-check {
   user-select: none;
@@ -117,23 +123,5 @@ export default {
     background-size: rem(12px);
     opacity: 0;
   }
-}
-
-.ae-check-content {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.ae-check.left > .ae-check-button {
-  order: 2;
-}
-
-.ae-check.left > .ae-check-content {
-  order: 1;
-}
-
-.ae-check.extend {
-  width: 100%;
 }
 </style>

--- a/src/components/ae-check/ae-check.vue
+++ b/src/components/ae-check/ae-check.vue
@@ -1,7 +1,14 @@
 <template>
   <label class="ae-check">
-    <input :type="type" :name="name" :value="value" :disabled="disabled">
+    <input
       :id="id"
+      :type="type"
+      :name="name"
+      :value="value"
+      :checked="isChecked"
+      :disabled="disabled"
+      @change="change"
+    >
     <span class="indicator">
       ✓
     </span>
@@ -10,6 +17,10 @@
 <script>
 export default {
   name: 'ae-check',
+  model: {
+    prop: 'checked',
+    event: 'change',
+  },
   props: {
     /**
      * ID of the component/input
@@ -24,7 +35,9 @@ export default {
     /**
      * value of component
      */
-    value: Boolean,
+    value: { type: [String, Number, Boolean], default: undefined },
+
+    checked: { type: [Array, String, Number, Boolean], default: false },
 
     /**
      * Define the type of the input
@@ -40,6 +53,26 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
+    },
+  },
+  computed: {
+    isChecked() {
+      return Array.isArray(this.checked)
+        ? this.checked.includes(this.value)
+        : this.checked === this.value || this.checked === true;
+    },
+  },
+  methods: {
+    change(event) {
+      let newValue;
+      if (this.value === undefined) newValue = event.target.checked;
+      else if (this.type === 'radio' || !Array.isArray(this.checked)) newValue = this.value;
+      else {
+        newValue = event.target.checked
+          ? [...this.checked, this.value]
+          : this.checked.filter(c => c !== this.value);
+      }
+      this.$emit('change', newValue);
     },
   },
 };


### PR DESCRIPTION
Expected to be used with AeListItem from #152 like in [Network settings screen](https://github.com/aeternity/aepp-identity/blob/c8232aedc92b011625ff28d5cac7f08d5eec262f/src/pages/SettingsNetwork.vue#L9-L19) of the Base app.
Restored `<input type="checkbox" />` behavior in Vue like in [this examples](https://vuejs.org/v2/guide/forms.html#Checkbox), according to [this guide](https://vuejs.org/v2/guide/components-custom-events.html#Customizing-Component-v-model).
Some changes based on [AeRadio](https://github.com/aeternity/aepp-identity/blob/5c787f1/src/components/AeRadio.vue) component from the Base app.