### PR TITLE
renaming ae-drop to ae-dropdown

### DIFF
--- a/src/components/ae-drop/index.js
+++ b/src/components/ae-drop/index.js
@@ -1,7 +1,0 @@
-import AeDrop from './ae-drop.vue';
-
-export const install = function (Vue) {
-  Vue.component('ae-drop', AeDrop);
-};
-
-export default AeDrop;

--- a/src/components/ae-dropdown/ae-dropdown.md
+++ b/src/components/ae-dropdown/ae-dropdown.md
@@ -1,5 +1,5 @@
 ```jsx
-<ae-drop>
+<ae-dropdown>
   <ae-icon name="list" size="20px" slot="button" />
   <li>
     <ae-icon name="copy" />
@@ -11,12 +11,12 @@
       Delete
     </ae-button>
   </li>
-</ae-drop>
+</ae-dropdown>
 ```
 
 ### prop: direction
 ```jsx
-<ae-drop direction="left">
+<ae-dropdown direction="left">
   <ae-icon name="list" size="20px" slot="button" />
   <li>
     <ae-icon name="copy" />
@@ -28,5 +28,5 @@
       Delete
     </ae-button>
   </li>
-</ae-drop>
+</ae-dropdown>
 ```

--- a/src/components/ae-dropdown/ae-dropdown.test.js
+++ b/src/components/ae-dropdown/ae-dropdown.test.js
@@ -1,6 +1,6 @@
 import { install } from './index';
 
-describe('ae-drop', () => {
+describe('ae-dropdown', () => {
   it('provides an install function', () => {
     expect(typeof install).toBe('function');
   });

--- a/src/components/ae-dropdown/ae-dropdown.vue
+++ b/src/components/ae-dropdown/ae-dropdown.vue
@@ -1,9 +1,9 @@
 <template>
-    <div class="ae-drop" :class="{ active }" v-clickaway="deactivate">
-      <button @click="activate" type="button" class="ae-drop-button">
+    <div class="ae-dropdown" :class="{ active }" v-clickaway="deactivate">
+      <button @click="activate" type="button" class="ae-dropdown-button">
         <slot name="button" />
       </button>
-      <ul class="ae-drop-menu"
+      <ul class="ae-dropdown-menu"
           :class="{ [direction]: Boolean(direction) }"
           @click.capture="deactivate">
         <slot />
@@ -14,7 +14,7 @@
 import { directive as clickaway } from 'vue-clickaway';
 
 export default {
-  name: 'ae-drop',
+  name: 'ae-dropdown',
   directives: { clickaway },
   data() {
     return { active: false };
@@ -46,18 +46,18 @@ export default {
 <style lang="scss" scoped>
   @import '../../styles/globals';
 
-  .ae-drop {
+  .ae-dropdown {
     position: relative;
     display: inline-block;
 
-    &.active > .ae-drop-menu {
+    &.active > .ae-dropdown-menu {
       opacity: 1;
       visibility: visible;
       z-index: $stack-4;
     }
   }
 
-  .ae-drop-button {
+  .ae-dropdown-button {
     @include size(48px);
 
     user-select: none;
@@ -82,7 +82,7 @@ export default {
     }
   }
 
-  .ae-drop-menu {
+  .ae-dropdown-menu {
     opacity: 0;
     visibility: hidden;
     z-index: $stack-4;

--- a/src/components/ae-dropdown/index.js
+++ b/src/components/ae-dropdown/index.js
@@ -1,0 +1,7 @@
+import AeDropdown from './ae-dropdown.vue';
+
+export const install = function (Vue) {
+  Vue.component('ae-dropdown', AeDropdown);
+};
+
+export default AeDropdown;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,7 +8,7 @@ import AeBadge from './ae-badge';
 import AeButton from './ae-button';
 import AeCard from './ae-card';
 import AeCheck from './ae-check';
-import AeDrop from './ae-drop';
+import AeDropdown from './ae-dropdown';
 import AeFlip from './ae-flip';
 import AeIcon from './ae-icon';
 import AeInput from './ae-input';
@@ -30,7 +30,7 @@ const components = {
   AeButton,
   AeCard,
   AeCheck,
-  AeDrop,
+  AeDropdown,
   AeFlip,
   AeIcon,
   AeInput,


### PR DESCRIPTION
@davidyuk pointed out in one of the comments that `ae-drop` might be confusing so I've renamed the plugin to `ae-dropdown`