### PR TITLE
Clear global styles

### DIFF
--- a/src/components/ae-icon/ae-icon.vue
+++ b/src/components/ae-icon/ae-icon.vue
@@ -74,10 +74,6 @@ export default {
     font-variant: normal;
     text-transform: none;
     speak: none;
-
-    /* Better Font Rendering =========== */
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
   }
 
   .ae-icon.round {

--- a/src/styles/rules.scss
+++ b/src/styles/rules.scss
@@ -14,7 +14,6 @@
 html, body {
   font-size: $base-font-size;
   line-height: $base-line-height;
-  caret-color: $color-error;
 
   /* Better Font Rendering */
   -webkit-font-smoothing: antialiased;

--- a/src/styles/rules.scss
+++ b/src/styles/rules.scss
@@ -13,7 +13,6 @@
 /// border-boxing fix
 html, body {
   font-size: $base-font-size;
-  font-weight: normal;
   line-height: $base-line-height;
   box-sizing: border-box;
   caret-color: $color-error;

--- a/src/styles/rules.scss
+++ b/src/styles/rules.scss
@@ -17,7 +17,7 @@ html, body {
   box-sizing: border-box;
   caret-color: $color-error;
 
-  /* Better Font Rendering =========== */
+  /* Better Font Rendering */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/styles/rules.scss
+++ b/src/styles/rules.scss
@@ -14,7 +14,6 @@
 html, body {
   font-size: $base-font-size;
   line-height: $base-line-height;
-  box-sizing: border-box;
   caret-color: $color-error;
 
   /* Better Font Rendering */
@@ -25,17 +24,11 @@ html, body {
 * {
   outline: none;
   outline: 0;
-  box-sizing: inherit;
 
   &:hover,
   &:focus,
   &:active {
     outline: none;
     outline: 0;
-  }
-
-  &:before,
-  &:after {
-    box-sizing: inherit;
   }
 }

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -6,7 +6,6 @@
 
 h1, h2, h3, h4, h5, h6, p {
   line-height: $base-line-height;
-  font-weight: normal;
 }
 
 p {

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -9,6 +9,5 @@ h1, h2, h3, h4, h5, h6, p {
 }
 
 p {
-  line-height: $base-line-height;
   font-size: $base-font-size;
 }

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -13,17 +13,3 @@ p {
   line-height: $base-line-height;
   font-size: $base-font-size;
 }
-
-a {
-  color: inherit;
-  transition: all $base-transition-time;
-  opacity: 0.75;
-  font-weight: bold;
-
-  &:hover,
-  &:focus {
-    opacity: 1;
-    text-decoration: underline;
-    color: inherit;
-  }
-}


### PR DESCRIPTION
Today I have added new components package to the Base app, and I ran into a problem with global styles of this package: they break stuff in the Base app, especially styles for `<a>`.

So, I propose to define as less as possible styles globally to avoid this problem, and make components package more compatible with other components packages.