### PR TITLE
improving address chunking, and copy-to-clipboard style for visibility

### DIFF
--- a/src/components/ae-address/ae-address.test.js
+++ b/src/components/ae-address/ae-address.test.js
@@ -1,0 +1,18 @@
+import { mount } from 'vue-test-utils';
+import AeAddress from './ae-address.vue';
+
+describe('AeAddress', () => {
+  [{
+    address: 'ak_123456789123456789123456789123456789123456789123',
+    chunked: ['ak_', '123', '456', '789', '123', '456', '789', '123', '456', '789', '123', '456', '789', '123', '456', '789', '123'],
+  }, {
+    address: 'ak_1234567891234567891234567891234567891234567891234',
+    chunked: ['ak_', '12', '345', '678', '912', '345', '678', '912', '345', '678', '912', '345', '678', '912', '345', '678', '912', '34'],
+  }, {
+    address: 'ak_12345678912345678912345678912345678912345678912345',
+    chunked: ['ak_', '12', '345', '678', '912', '345', '678', '912', '345', '678', '912', '345', '678', '912', '345', '678', '912', '345'],
+  }].forEach(({ address, chunked }) => it(`formats address with length ${address.length}`, () => {
+    const wrapper = mount(AeAddress, { propsData: { value: address } });
+    expect(wrapper.vm.chunked).toEqual(chunked);
+  }));
+});

--- a/src/components/ae-address/ae-address.vue
+++ b/src/components/ae-address/ae-address.vue
@@ -68,7 +68,7 @@ export default {
      * @return {String[]}
      */
     chunked() {
-      return this.value.match(/.{1,3}/g);
+      return this.value.match(/^(\w{2}_)|.{2}(?=.{47,53})|.{2,3}/g);
     },
   },
 };
@@ -105,10 +105,6 @@ export default {
     }
   }
 
-  &.v-copied-to-clipboard {
-    opacity: 0.4;
-  }
-
   &.v-copied-to-clipboard:before {
     @extend %face-mono-base;
 
@@ -117,7 +113,8 @@ export default {
     justify-content: center;
     align-items: center;
     font-weight: 500;
-    background: rgba($color-neutral-positive-1, 0.25);
+    color: $color-neutral-negative-3;
+    background: rgba($color-neutral-positive-1, 0.9);
     position: absolute;
     top: 0;
     right: 0;

--- a/src/components/ae-address/ae-address.vue
+++ b/src/components/ae-address/ae-address.vue
@@ -68,7 +68,7 @@ export default {
      * @return {String[]}
      */
     chunked() {
-      return this.value.match(/^(\w{2}_)|.{2}(?=.{47,53})|.{2,3}/g);
+      return this.value.match(/^\w{2}_|.{2}(?=.{47,48}$)|.{2,3}/g);
     },
   },
 };


### PR DESCRIPTION
- Now the chunking of the address happens in the format of: `ak_` `xx` `xxx` | `xx`$
- Improve copy-to-clipboard style on click, changing opacity for visibility and font-color to a darker one