### PR TITLE
adding new address layout

### DIFF
--- a/src/components/ae-address/ae-address.md
+++ b/src/components/ae-address/ae-address.md
@@ -11,6 +11,10 @@
   <ae-address value="ak_QY8VNEkhj7omMUjAvfVBq2NjTDy895LBYbk7qVxQo1qT8VqfE" length="short" />
 ``` 
 
+```jsx
+  <ae-address value="ak_QY8VNEkhj7omMUjAvfVBq2NjTDy895LBYbk7qVxQo1qT8VqfE" length="flat" />
+``` 
+
 ### prop: gap
 ```jsx
   <ae-address value="ak_QY8VNEkhj7omMUjAvfVBq2NjTDy895LBYbk7qVxQo1qT8VqfE" length="medium" gap="1.5rem" />

--- a/src/components/ae-address/ae-address.vue
+++ b/src/components/ae-address/ae-address.vue
@@ -4,6 +4,7 @@
     class="ae-address"
     :class="[ length ]"
     :style="{ gridGap: gap }"
+    :title="value"
     v-copy-to-clipboard="value"
     v-remove-spaces-on-copy
   >
@@ -25,6 +26,11 @@
       <li>...</li>
       <li v-for="chunk in chunked.slice(16, 18)" :key="chunk">
         {{ chunk }}
+      </li>
+    </template>
+    <template v-else-if="length === 'flat'">
+      <li>
+        {{ chunked.join('') }}
       </li>
     </template>
     <template v-else>
@@ -52,7 +58,7 @@ export default {
 
     /**
      * Set the length of the address
-     * valid properties: `medium, short`
+     * valid properties: `medium, short, flat`
      */
     length: String,
 
@@ -102,6 +108,14 @@ export default {
 
     &.v-copied-to-clipboard:before {
       font-size: 0.875rem;
+    }
+  }
+
+  &.flat {
+    grid-template-columns: 1fr;
+
+    > li {
+      word-break: break-all;
     }
   }
 


### PR DESCRIPTION
- adding a new layout for the address
  - the layout displays the address fully without breaks or grids in between
- adding `title` property to display full address on hover based on https://github.com/aeternity/aepp-components/issues/202#issuecomment-435790621