### PR TITLE
add :active style of ae-button as :hover effekt for desktop support

### DIFF
--- a/src/components/ae-button/ae-button.vue
+++ b/src/components/ae-button/ae-button.vue
@@ -96,6 +96,7 @@ export default {
   &:hover,
   &:focus {
     text-decoration: none;
+    opacity: 0.85;
   }
 
   &:active:not(:disabled) {


### PR DESCRIPTION
- use `:active` state style, lowering opacity, on button for its `:hover` state to support desktop use
- this is related to style issues on the https://github.com/aeternity/aepp-token-migration and https://github.com/aeternity/aepp-token-migration-landing  project.