### PR TITLE
AeIcon: Remove color: inherit

### DIFF
--- a/src/components/ae-icon/ae-icon.vue
+++ b/src/components/ae-icon/ae-icon.vue
@@ -72,7 +72,6 @@ export default {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  color: inherit;
 
   &.primary {
     color: $color-primary;


### PR DESCRIPTION
This PR fixes the color of AeIcon inside of link.

Example:
```vue
<a href="http://example.com/1">link <ae-icon name="save" /></a>
<a href="http://example.com">visited link <ae-icon name="save" /></a>
```

How it displays before this change:
![screenshot from 2019-01-25 08-07-11](https://user-images.githubusercontent.com/9007851/51730669-b2d55300-2078-11e9-8b92-adc40ce3ccf9.png)

After: 
![screenshot from 2019-01-25 08-07-39](https://user-images.githubusercontent.com/9007851/51730676-b7017080-2078-11e9-9ceb-083e479fdc98.png)
