### PR TITLE
AeIcon: Align middle by default

### DIFF
--- a/src/components/ae-icon/ae-icon.vue
+++ b/src/components/ae-icon/ae-icon.vue
@@ -73,6 +73,7 @@ export default {
   justify-content: center;
   align-items: center;
   color: inherit;
+  vertical-align: middle;
 
   &.primary {
     color: $color-primary;


### PR DESCRIPTION
As I see in designs AeIcon is aligned by middle in more cases than by the baseline (default value).

Example:
```
<ae-icon name="copy" />Ag<ae-icon name="copy" />
```
Before: 
![screenshot from 2019-01-25 08-27-08](https://user-images.githubusercontent.com/9007851/51731399-24160580-207b-11e9-9a8c-82412a9c99b5.png)
After: 
![screenshot from 2019-01-25 08-26-50](https://user-images.githubusercontent.com/9007851/51731403-28dab980-207b-11e9-9183-33c194178d1c.png)
